### PR TITLE
QOL-9055 Prepare for Amazon Linux 2

### DIFF
--- a/ckanext/harvester_data_qld_geoscience/plugin.py
+++ b/ckanext/harvester_data_qld_geoscience/plugin.py
@@ -5,7 +5,7 @@ from six.moves.urllib.parse import urlencode
 import ckan.plugins as plugins
 import ckantoolkit as toolkit
 
-import helpers
+from . import helpers
 
 from ckanext.harvest.harvesters.ckanharvester import CKANHarvester, ContentFetchError, SearchError
 from ckan.lib.helpers import json

--- a/ckanext/harvester_data_qld_geoscience/plugin.py
+++ b/ckanext/harvester_data_qld_geoscience/plugin.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import six
-import urllib
+from six.moves.urllib.parse import urlencode
 import ckan.plugins as plugins
 import ckantoolkit as toolkit
 
@@ -298,7 +298,7 @@ class GeoScienceCKANHarvester(CKANHarvester):
         pkg_ids = set()
         previous_content = None
         while True:
-            url = base_search_url + '?' + urllib.urlencode(params)
+            url = base_search_url + '?' + urlencode(params)
             log.debug('Searching for CKAN datasets: %s', url)
             try:
                 content = self._get_content(url)


### PR DESCRIPTION
- Make relative imports explicit so Py3 is happy
- Use 'six' to handle Python 2/3 compatibility