### PR TITLE
[QOLDEV-349] replace deprecated 'unicode' validator

### DIFF
--- a/ckanext/harvester_data_qld_geoscience/geoscience_dataset.json
+++ b/ckanext/harvester_data_qld_geoscience/geoscience_dataset.json
@@ -58,7 +58,7 @@
     {
       "field_name": "version",
       "label": "Version",
-      "validators": "scheming_required unicode package_version_validator",
+      "validators": "scheming_required unicode_safe package_version_validator",
       "form_placeholder": "1.0",
       "required": true
     },


### PR DESCRIPTION
- Built-in str type is no longer usable as a validator as of CKAN 2.10, switch to unicode_safe